### PR TITLE
Rewrite moderation and owner cogs

### DIFF
--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -24,202 +24,169 @@ import dotenv
 from discord import Activity, ActivityType
 from discord import Member
 from discord.ext import commands
+from typing import Union
 
 class Moderation(commands.Cog):
-	
-	def __init__(self, bot):
-		self.bot = bot
-		
-	@commands.Cog.listener()
-	async def on_ready(self):
-		print(f"{self.__class__.__name__} Cog has been loaded\n-----")
+    def __init__(self, bot):
+        self.bot = bot
 
+        self.muted_perms = discord.Permissions(send_messages=False, speak=False)
 
-	@commands.command(aliases=['b'])
-	@commands.has_permissions(ban_members=True)
-	async def ban(self, ctx, member: discord.Member, *, reason="Reason not provided."):
-	    await member.kick(reason=reason)
-	    embed = discord.Embed(
-	    colour = discord.Colour.blurple(),
-	    title = f"__New Ban__"
-	    )
-	    embed.add_field(name="**Banned by:**", value=f"{ctx.author}", inline=False)
-	    emebd.add_field(name="**Reason:**", value=f"{reason}", inline=False)
-	    embed.add_field(name="**Member kicked:**", value=f"{member}", inline=False)
-	    
-	    chan = await member.create_dm()
-	    
-	    await chan.send(embed=embed)
-	    await ctx.send(embed=embed)
+    async def _get_mute_role(self, guild_id: int):
+        # automate the retrieval and (if necessary) instantiation of the
+        # muted role
+        mute_role = discord.utils.get(ctx.guild.roles, name="Muted")
 
-	@commands.command(aliases=['ub'])
-	@commands.has_permissions(ban_members=True)
-	async def unban(self,ctx, *,member):
-		banned_users = await ctx.guild.bans()
-		member_name, member_disc = member.split('#')
-		
-		for banned_entry in banned_users:
-			user = banned_entry.user
-			
-			if(user.name, user.discriminator)==(member_name,member_disc):
-			
-				await ctx.guild.unban(user)
-				embed = discord.Embed(
-				colour = discord.Colour.red(),
-				title = "Unbanned {user}"
-				)
-				
-				chan = await member.create_dm()
-				
-				await chan.send(embed=embed)
-				await ctx.send(embed=embed)
+        if not mute_role:
+            mute_role = await guild.create_role(name="Muted", permissions=self.muted_perms)
+        return mute_role
 
-	@commands.command(aliases=['k'])
-	@commands.has_permissions(kick_members=True)
-	async def kick(self, ctx, member: discord.Member, *, reason="Reason not provided."):
-	    await member.kick(reason=reason)
-	    embed = discord.Embed(
-	    colour = discord.Colour.blurple(),
-	    title = f"__New Kick__"
-	    )
-	    embed.add_field(name="**Kicked by:**", value=f"{ctx.author}", inline=False)
-	    emebd.add_field(name="**Reason:**", value=f"{reason}", inline=False)
-	    embed.add_field(name="**Member kicked:**", value=f"{member}", inline=False)
-	    
-	    chan = await member.create_dm() 
-	    
-	    await chan.send(embed=embed)
-	    await ctx.send(embed=embed)
-	    
-	@commands.command(aliases=['c'])
-	async def clear(self, ctx, amount):
-		    if amount is None:
-		    	await ctx.channel.purge(limit=2)
-		    	await asyncio.sleep(1)
-		    	embed = discord.Embed(
-		    	colour = discord.Colour.green(),
-		    	title = "\u2800",
-		    	description = "Cleared 2 messages!"	
-		    	)
-		    	await ctx.send(embed=embed)
-		    else:
-		    	await ctx.channel.purge(limit=amount)
-		    	await asyncio.sleep(1)
-		    	embed = discord.Embed(
-		    	colour = discord.Colour.green(),
-		    	title = "\u2800",
-		    	description = "Cleared {amount} messages!"	
-		    	)
-		    	await ctx.send(embed=embed)
-	    	
-	@commands.command(aliases=['m'])
-	@commands.has_permissions(kick_members=True)
-	async def mute(self,ctx, member: discord.Member, *, reason="Not Provided."):
-	    role = discord.utils.get(ctx.guild.roles, name="Muted")
-	    guild = ctx.guild
-	    if role not in guild.roles:
-	        perms = discord.Permissions(send_messages=False, speak=False)
-	        await guild.create_role(name="Muted", permissions=perms)
-	        await member.add_roles(role)
-	        embed = discord.Embed(
-	        colour = discord.Colour.blue(),
-	        title = f"__New Mute__"
-	        )	    
-	        embed.add_field(name=f"!", value = f"{member} Was muted.\nReason:{reason}", inline = False)
-	        await ctx.send(embed=embed)
-	    else:
-	        await member.add_roles(role) 
-	        embed = discord.Embed(
-	        colour = discord.Colour.blue(),
-	        title = f"__New Mute__"
-	        )	    
-	        embed.add_field(name=f"!", value = f"{member} Was muted.\nReason:{reason}", inline = False)
-	        await ctx.send(embed=embed)	    
+    async def _do_giveaway(self, ctx: commands.Context, seconds: int, prize: str):
+        # handle giveaway logic separately to run within a task
+        winner = None
+        giveawayembed = discord.Embed(
+            title="🎉 __New Giveaway!__ 🎉",
+            colour=discord.Color.green(),
+            description="React To :tada: To Enter The Giveaway!"
+            )
 
-	@commands.command(aliases=['demute', 'um']) 
-	@commands.has_permissions(kick_members=True)
-	async def unmute(self,ctx, member: discord.Member):
-		role = discord.utils.get(ctx.guild.roles, name="Muted")
-		await member.remove_roles(role)
-		embed = discord.Embed(
-		colour = discord.Colour.blue(),
-		ttle = f"__Unmute__"
-		)	    
-		embed.add_field(name=f"!", value = f"{member} Was muted.\nReason:{reason}", inline=False)
-		await ctx.send(embed=embed)
+        giveawayembed.add_field(name="Prize", value=prize, inline=False)
+        giveawayembed.add_field(name="Hosted by", value=f"{ctx.author.mention}", inline=False)
+        giveawayembed.add_field(name="Ends in", value=f"{seconds}s")
+        giveawayembed.set_thumbnail(url=ctx.author.avatar_url)
 
-	@commands.command(aliases=['w'])
-	
-	@commands.has_permissions(kick_members = True)
-	
-	async def warn(self,ctx, member : discord.Member, *, arg):
-	
-	    author = ctx.message.author
-	    guild = ctx.guild
-	    channel = get(guild.text_channels, name='warn-logs')
-	    if channel is None:
-	        channel = await guild.create_text_channel('warn-logs')
-	
-	
-	
-	    embed = discord.Embed(
-	
-	        color = discord.Color.blue()
-	
-	
-	
-	    )
-	
-	
-	
-	    embed.set_author(name='Warning')
-	
-	    embed.add_field(name='!', value=f'{member} has been warned!', inline=False)
-	
-	    embed.add_field(name='!', value=f'{member} has been warned because: {arg}', inline=False)
-	    
-	    chan = await member.create_dm()
-	    
-	    await channel.send(embed=embed)
-	    await chan.send(embed=embed)	    
+        msg = await ctx.send(embed=giveawayembed)
+        await msg.add_reaction("🎉")
+        await asyncio.sleep(seconds)
 
-	@commands.command(aliases=['g'])
-	@commands.has_permissions(administrator=True)
-	@commands.is_owner()
-	async def giveaway(self, ctx, time: int, *, prize):
-	        giveawayembed = discord.Embed(
-	            title="🎉 __New Giveaway!__ 🎉",
-	            colour=discord.Color.green(),
-	            description="React To :tada: To Enter The Giveaway!"
-	            )
-	
-	        giveawayembed.add_field(name="Prize", value="{}".format(prize), inline=False)
-	        giveawayembed.add_field(name="Hosted by", value=f"{ctx.author.mention}", inline=False)
-	        giveawayembed.add_field(name="Ends in", value="{}s".format(time))
-	        giveawayembed.set_thumbnail(url=ctx.author.avatar_url)
-	
-	        msg = await ctx.send(embed=giveawayembed)
-	
-	        await msg.add_reaction("🎉")
-	
-	        await asyncio.sleep(time)
-	
-	        msg = await msg.channel.fetch_message(msg.id)
-	        winner = None
-	        
-	        for reaction in msg.reactions:
-	            if reaction.emoji == "🎉":
-	                users = await reaction.users().flatten()
-	                users.remove(client.user)
-	                winner = random.choice(users)
-	
-	        if winner is not None:
-	            endembed = discord.Embed(
-	                title="Giveaway ended!",
-	                colour = discord.Colour.green(),
-	                description="Prize: {}\nWinner: {}".format(prize, winner))
-	
-	            await msg.edit(embed=endembed)	    	    	    	    	    	    
-	    	    	    	    	    	    	    	    	    
+        msg = await msg.channel.fetch_message(msg.id)
+
+        for reaction in msg.reactions:
+            if str(reaction.emoji) == "🎉":
+                users = await reaction.users().flatten()
+                users.remove(client.user)
+                winner = random.choice(users)
+                # no need to continue iterating, 
+                break
+
+        embed = discord.Embed(
+            title="Giveaway ended!",
+            colour = discord.Colour.green(),
+            description=f"Prize: {prize}\nWinner: {winner}")
+        await msg.edit(embed=embed)    
+        
+    @commands.Cog.listener()
+    async def on_ready(self):
+        print(f"{self.__class__.__name__} Cog has been loaded\n-----")
+
+    @commands.command(aliases=['b'])
+    @commands.has_permissions(ban_members=True)
+    async def ban(self, ctx, member: Union[discord.Member, int], *, reason="Reason not provided."):
+        # the formatting was bothering, able to be reverted - this is
+        # the only snippet that is converted
+        embed = discord.Embed(
+            colour = discord.Colour.blurple(),
+            title = f"__New Ban__"
+        )
+        embed.add_field(name="**Banned by:**", value=f"{ctx.author}", inline=False)
+        emebd.add_field(name="**Reason:**", value=f"{reason}", inline=False)
+        embed.add_field(name="**Member kicked:**", value=f"{member}", inline=False)
+
+        if isinstance(member, discord.Member):
+            await member.send(embed=embed)
+            await member.ban(reason=reason)
+        else:
+            await ctx.guild.ban(discord.Object(member))
+        await ctx.send(embed=embed)
+
+    @commands.command(aliases=['ub'])
+    @commands.has_permissions(ban_members=True)
+    async def unban(self, ctx, member_id: int):
+        user = self.bot.get_user(member_id)
+        title = f"Unbanned {user}"
+
+        if user is None:
+            title = f"Unbanned user with ID {member_id}"
+        embed = discord.Embed(
+        colour = discord.Colour.red(),
+        title = title
+        )
+
+        await ctx.guild.unban(discord.Object(member_id))
+        await ctx.send(embed=embed)
+
+    @commands.command(aliases=['k'])
+    @commands.has_permissions(kick_members=True)
+    async def kick(self, ctx, member: discord.Member, *, reason="Reason not provided."):
+        embed = discord.Embed(
+        colour = discord.Colour.blurple(),
+        title = f"__New Kick__"
+        )
+        embed.add_field(name="**Kicked by:**", value=f"{ctx.author}", inline=False)
+        emebd.add_field(name="**Reason:**", value=f"{reason}", inline=False)
+        embed.add_field(name="**Member kicked:**", value=f"{member}", inline=False)
+        
+        await member.kick(reason=reason)
+        await ctx.send(embed=embed)
+        
+    @commands.command(aliases=['c'])
+    async def clear(self, ctx, amount: int = 2):
+        embed = discord.Embed(
+        colour = discord.Colour.green(),
+        title = "\u2800",
+        description = "Cleared {amount} messages!"  
+        )
+
+        await ctx.channel.purge(limit=amount)
+        await asyncio.sleep(1)
+        await ctx.send(embed=embed)
+            
+    @commands.command(aliases=['m'])
+    @commands.has_permissions(kick_members=True)
+    async def mute(self, ctx, member: discord.Member, *, reason="Not Provided."):
+        embed = discord.Embed(
+        colour = discord.Colour.blue(),
+        title = f"__New Mute__"
+        )       
+        embed.add_field(name=f"!", value = f"{member} Was muted.\nReason:{reason}", inline = False)
+        role = await self._get_mute_role(ctx.guild.id)
+
+        await member.add_roles(role)
+        await ctx.send(embed=embed)
+
+    @commands.command(aliases=['demute', 'um']) 
+    @commands.has_permissions(kick_members=True)
+    async def unmute(self, ctx, member: discord.Member):
+        role = await self._get_mute_role(ctx.guild.id)
+        embed = discord.Embed(
+        colour = discord.Colour.blue(),
+        ttle = f"__Unmute__"
+        )
+        embed.add_field(name=f"!", value = f"{member} Was muted.\nReason:{reason}", inline=False)
+
+        await member.remove_roles(role)
+        await ctx.send(embed=embed)
+
+    @commands.command(aliases=['w'])
+    @commands.has_permissions(kick_members = True)
+    async def warn(self, ctx, member: discord.Member, *, arg):
+        channel = discord.utils.get(ctx.guild.text_channels, name='warn-logs')
+
+        if channel is None:
+            channel = await guild.create_text_channel('warn-logs')
+        embed = discord.Embed(color = discord.Color.blue())
+        embed.set_author(name='Warning')
+        embed.add_field(name='!', value=f'{member} has been warned!', inline=False)
+        embed.add_field(name='!', value=f'{member} has been warned because: {arg}', inline=False)
+        
+        await member.send(embed=embed)        
+        await channel.send(embed=embed)
+
+    @commands.command(aliases=['g'])
+    @commands.has_permissions(administrator=True)
+    @commands.is_owner()
+    async def giveaway(self, ctx, seconds: int, *, prize):
+        self.bot.loop.create_task(self._do_giveaway(ctx, seconds, prize))
+                                                                        
 def setup(bot):
-	bot.add_cog(Moderation(bot))
+    bot.add_cog(Moderation(bot))

--- a/cogs/owner.py
+++ b/cogs/owner.py
@@ -1,51 +1,47 @@
 import discord
 import asyncio
 import json
+import traceback
 from discord.ext import commands
 
-class Owner(commands.Cog):
-	
-	def __init__(self, bot):
-		self.bot = bot
-	
-	@commands.Cog.listener()
-	async def on_ready(self):
-		print(f"{self.__class__.__name__} Cog has been loaded\n-----")
-		
-	@commands.command(name='load', hidden=True)
-	@commands.is_owner()
-	async def load(self, ctx, *, cog: str):
-	            try:
-	            	self.bot.load_extension(cog)
-	            except Exception as e:
-	            	await ctx.send(f'**`ERROR:`** {type(e).__name__} - {e}')
-	            else:
-	            	await ctx.send('**`SUCCESS`**')
-	@commands.command(name='unload', hidden=True)
-	@commands.is_owner()
-	async def unload(self, ctx, *, cog: str):
-	           	try:
-	           		self.bot.unload_extension(cog)
-	           	except Exception as e:
-	           			await ctx.send(f'**`ERROR:`** {type(e).__name__} - {e}')
-	           	else:
-	           			await ctx.send('**`SUCCESS`**')
+# adding command_attrs= kwarg allows all commands being added now and
+# in the future to be automatically and implicitly hidden
+class Owner(commands.Cog, command_attrs={"hidden": True}):
+    def __init__(self, bot):
+        self.bot = bot
 
-	@commands.command(name='reload', hidden=True)
-	@commands.is_owner()
-	async def reload(self, ctx, *, cog: str):
-	           try:
-	           	self.bot.unload_extension(cog)
-	           	self.bot.load_extension(cog)
-	           except Exception as e:
-	           	await ctx.send(f'**`ERROR:`** {type(e).__name__} - {e}')
-	           else:
-	           	await ctx.send('**`SUCCESS`**')
-	
-	@commands.Cog.listener()
-	async def on_member_ban(self, guild, user):
-		
-		print(f'{user} was banned from {guild.name}\n{guild.id}')
-        	        	        	        	        	        	
+    async def _error_wrap(self, ctx, func, *args, **kwargs):
+        try:
+            func(*args, **kwargs)
+        except Exception as e:
+            formatted = traceback.format_exception(type(e), e, e.__traceback__)
+            joined = ("").join(formatted)
+            await ctx.send(f'**`ERROR:`** {joined}')
+        else:
+            await ctx.send('**`SUCCESS`**')
+
+    @commands.Cog.listener()
+    async def on_ready(self):
+        print(f"{self.__class__.__name__} Cog has been loaded\n-----")
+
+    @commands.command(name='load')
+    @commands.is_owner()
+    async def load(self, ctx, *, cog: str):
+        await self._error_wrap(ctx, self.bot.load_extension, cog)
+
+    @commands.command(name='unload')
+    @commands.is_owner()
+    async def unload(self, ctx, *, cog: str):
+        await self._error_wrap(ctx, self.bot.unload_extension, cog)
+
+    @commands.command(name='reload')
+    @commands.is_owner()
+    async def reload(self, ctx, *, cog: str):
+        await self._error_wrap(ctx, self.bot.reload_extension, cog)
+    
+    @commands.Cog.listener()
+    async def on_member_ban(self, guild, user):
+        print(f'{user} was banned from {guild.name}\n{guild.id}')
+
 def setup(bot):
-	bot.add_cog(Owner(bot))	
+    bot.add_cog(Owner(bot)) 


### PR DESCRIPTION
**Note:** I know this looks like I have rewritten the entirety of these files but bare with me, this is truly not the case and was due to my IDE automatically converting the indentation to spaces.

### Apply Changes
**From the Discord.py server's tags system:**
- hackban
- hackunban
- lucas ban
- typehints
- union typehint
- bot vars

**Outside of the tags system:**
1. When using `TextChannel.purge` ([doc](https://discordpy.readthedocs.io/en/latest/api.html?highlight=purge#discord.TextChannel.purge)), the `limit` kwarg is stated to be either `None` or an `int` however parameters by default are `str`. This has been changed so that the parameter will instead attempt to be converted into an `int`.
2. (Addressing your `clear` command) The `amount` parameter will never be `None` and is instead a required parameter since you have either not given it a default value or not set it as `typing.Optional` via typehints. With this in mind, `amount` will never be `None` and this therein renders your `if amount is None:` conditional obselete.
3. (Addressing your `mute/unmute` commands) Bot variables are useful when applying DRY so as to prevent repetitive instantiation (constantly creating/recreating) of an object, especially if this object's original use case does not change or is not impacted by this, hence the muted role's permissions were cached in `self.muted_perms`.
4. (Addressing your `giveaway` command) Giveaway systems are generally created using tasks instead of waiting inside of a command. This touches on the inner workings of the `asyncio` standard library but the general gist of it is that anything you `await` works similarly to a function - until it returns, the command will not move on. Tasks on the other hand will run the coroutine and allow your command to move on with the rest of it.

**Separate Mentions:**
1. Adding on to the `clear` and other, *similarly* designed commands, DRY (**D**on't **R**epeat **Y**ourself) is violated. This is not something that is imperative to follow but it can help improve code efficiency. This is specially demonstrated in the edited variant of your `owner.py` file and your `mute/unmute` commands.
2. Adding onto `?tag union typehint`, this is useful when you want to pass either an ID or a member mention within a command like in your `ban` command.
3. General inconsistencies: while I do not know how you have been able to run your bot without running into any `TabError`s, I can say that it is imperative you stick to a consistent way of programming later on and hold that consistency for the type of tabbing you would like to use now. As it stands, your program is littered with a mixture of spaces, tabs and levels of indentation, e.g.

```py

try:
    self.bot.unload_extension(cog)  # YES
except Exception as e:
        await ctx.send(f'**`ERROR:`** {type(e).__name__} - {e}')  # NO
else:
        await ctx.send('**`SUCCESS`**')  # NO
```

According to [PEP 8](https://www.python.org/dev/peps/pep-0008/), it is recommended to use 4 spaces for your indentation as it improves readability and generally looks clean as explained [here](https://www.python.org/dev/peps/pep-0008/#indentation).